### PR TITLE
Attempt to make the login-based view better usable, thereby fixing #8 and logout problems

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,10 @@ Installation and configuration
     SHIBBOLETH_USER_KEY='<shibboleth-attribute>'
   ```
 	
-  * Map Shibboleth attributes to Django User models. The attributes must be stated in the form they have in the HTTP headers.
-    Use this to populate the Djangoe User object from Shibboleth attributes. A username is always required.
+  * Map Shibboleth attributes to Django User models. Use this to populate the Djangoe User object with additional Shibboleth attributes, but do NOT overwrite `username`. The attributes must be stated in the form they have in the request.META dictionary, which should be the same as in the configuration of your shibboleth SP.
+    
 
-    The first element of the tuple states if the attribute is required or not. If a reqired element is not found in the parsed 
-    Shibboleth headers, an exception will be raised.
+    The first element of the tuple states if the attribute is required or not. If a reqired element is not found in the request.META dictionary, an exception will be raised.
     (True, "required_attribute")
     (False, "optional_attribute).
 

--- a/README.md
+++ b/README.md
@@ -56,11 +56,19 @@ Installation and configuration
 
 
 
-  * Login url - set this to the login handler of your shibboleth installation. In most cases, this will be something like:
+  * Login and Logout url - set this to the login/Logout handler of your shibboleth installation. 
+    In most cases, this will be something like:
 
-   ```python
-   LOGIN_URL = 'https://your_domain.edu/Shibboleth.sso/Login'
+    ```python
+    SHIBBOLETH_LOGIN_URL = 'https://your_domain.edu/Shibboleth.sso/Login'
+    SHIBBOLETH_LOGOUT_URL = 'https://your_domain.edu/Shibboleth.sso/Logout'
    ```
+ * Set the django `LOGIN_URL` to the login-view provided by this package:
+   
+    ```python
+    LOGIN_URL = '/shib/login/'
+    ```
+    You can also manually address this url. It is necessary to specify a redirect location using the url parameter `next`.
 
  * Apache configuration - make sure the shibboleth attributes are available to the app.  The app url doesn't need to require Shibboleth but the Shibboleth headers need to be available to the Django application.  
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 django-shibboleth-remoteuser
 ============================
 
-Middleware for using Shibboleth with Django.  Requires Django 1.3 or above for RemoteAuthMiddleware.
+Middleware for using Shibboleth with Django.  Requires Django 1.6 or above.
 
-TODO: Follow this pattern more closely: https://docs.djangoproject.com/en/dev/howto/auth-remote-user/
-But make sure to take  REMOTE_USER as a user-claim and check it against the permanent-id in the backend.
 
 TODO: Fix travis
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,11 @@ Installation and configuration
     )
     ```
 
-
+  * Define the shibboleth user key. This is the shibboleth attribute that is used to identify the user. It becomes the user name in django.
+  ```python
+    SHIBBOLETH_USER_KEY='<shibboleth-attribute>'
+  ```
+	
   * Map Shibboleth attributes to Django User models. The attributes must be stated in the form they have in the HTTP headers.
     Use this to populate the Djangoe User object from Shibboleth attributes. A username is always required.
 
@@ -50,8 +54,8 @@ Installation and configuration
 
     ```python
     SHIBBOLETH_ATTRIBUTE_MAP = {
-       "shib-user": (True, "username"),
-       "shib-given-name": (True, "first_name")
+       "shib-given-name": (True, "first_name"),
+	...
     }
     ```
 

--- a/README.md
+++ b/README.md
@@ -3,14 +3,17 @@ django-shibboleth-remoteuser
 
 Middleware for using Shibboleth with Django.  Requires Django 1.3 or above for RemoteAuthMiddleware.
 
-[![Build Status](https://secure.travis-ci.org/Brown-University-Library/django-shibboleth-remoteuser.png?branch=master)](http://travis-ci.org/Brown-University-Library/django-shibboleth-remoteuser)
+TODO: Follow this pattern more closely: https://docs.djangoproject.com/en/dev/howto/auth-remote-user/
+But make sure to take  REMOTE_USER as a user-claim and check it against the permanent-id in the backend.
+
+TODO: Fix travis
 
 Installation and configuration
 ------
  * Either checkout and run ```python setup.py install``` or install directly from Github with pip:
 
    ```
-   pip install git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git
+   pip install git+https://github.com/???????django-shibboleth-remoteuser.git
    ```
 
  * In settings.py :
@@ -47,10 +50,8 @@ Installation and configuration
 
     ```python
     SHIBBOLETH_ATTRIBUTE_MAP = {
-       "HTTP_SHIB_USER": (True, "username"),,
-       "HTTP_SHIB_GIVEN_NAME": (True, "first_name"),
-       "HTTP_SHIP_SN": (True, "last_name"),
-       "HTTP_SHIB_MAIL": (False, "email"),
+       "shib-user": (True, "username"),
+       "shib-given-name": (True, "first_name")
     }
     ```
 
@@ -70,13 +71,12 @@ Installation and configuration
     ```
     You can also manually address this url. It is necessary to specify a redirect location using the url parameter `next`.
 
- * Apache configuration - make sure the shibboleth attributes are available to the app.  The app url doesn't need to require Shibboleth but the Shibboleth headers need to be available to the Django application.  
+ * Apache configuration - make sure the shibboleth attributes are available to the app.  The shibboleth variables are passed into the HttpRequest.META dictionary via wsgi.
 
     ```
     <Location /app>
       AuthType shibboleth
       Require shibboleth
-      ShibUseHeaders On
     </Location>
     ```
 

--- a/shibboleth/app_settings.py
+++ b/shibboleth/app_settings.py
@@ -24,6 +24,6 @@ SHIBBOLETH_LOGOUT_URL = getattr(settings, 'SHIBBOLETH_LOGOUT_URL', None)
 #users logout from Shibboleth.
 LOGOUT_REDIRECT_URL = getattr(settings, 'SHIBBOLETH_LOGOUT_REDIRECT_URL', None)
 #Name of key.  Probably no need to change this.  
-LOGOUT_SESSION_KEY = getattr(settings, 'SHIBBOLETH_FORCE_REAUTH_SESSION_KEY', 'shib_force_reauth')
+SHIBBOLETH_USER_KEY = getattr(settings, 'SHIBBOLETH_USER_KEY', None)
 
 

--- a/shibboleth/app_settings.py
+++ b/shibboleth/app_settings.py
@@ -11,15 +11,15 @@ SHIB_ATTRIBUTE_MAP = getattr(settings, 'SHIBBOLETH_ATTRIBUTE_MAP', default_shib_
 #Set to true if you are testing and want to insert sample headers.
 SHIB_MOCK_HEADERS = getattr(settings, 'SHIBBOLETH_MOCK_HEADERS', False)
 
-LOGIN_URL = getattr(settings, 'LOGIN_URL', None)
+SHIBBOLETH_LOGIN_URL = getattr(settings, 'SHIBBOLETH_LOGIN_URL', None)
 
-if not LOGIN_URL:
-    raise ImproperlyConfigured("A LOGIN_URL is required.  Specify in settings.py")
+if not SHIBBOLETH_LOGIN_URL:
+    raise ImproperlyConfigured("A SHIBBOLETH_LOGIN_URL is required.  Specify in settings.py")
 
 #Optional logout parameters
 #This should look like: https://sso.school.edu/idp/logout.jsp?return=%s
 #The return url variable will be replaced in the LogoutView.
-LOGOUT_URL = getattr(settings, 'SHIBBOLETH_LOGOUT_URL', None)
+SHIBBOLETH_LOGOUT_URL = getattr(settings, 'SHIBBOLETH_LOGOUT_URL', None)
 #LOGOUT_REDIRECT_URL specifies a default logout page that will always be used when
 #users logout from Shibboleth.
 LOGOUT_REDIRECT_URL = getattr(settings, 'SHIBBOLETH_LOGOUT_REDIRECT_URL', None)

--- a/shibboleth/backends.py
+++ b/shibboleth/backends.py
@@ -20,7 +20,7 @@ class ShibbolethRemoteUserBackend(RemoteUserBackend):
     # Create a User object if not already in the database?
     create_unknown_user = True
 
-    def authenticate(self, remote_user, META_HEADERS,session):
+    def authenticate(self, remote_user, META_HEADERS):
         """
         The username passed as ``remote_user`` is considered trusted.  This
         method simply returns the ``User`` object with the given username,
@@ -37,8 +37,7 @@ class ShibbolethRemoteUserBackend(RemoteUserBackend):
 
         # Make sure we have all required Shiboleth elements before proceeding.
         shib_meta, error = self.parse_attributes(META_HEADERS)
-        # Add parsed attributes to the session. # Why is this necessary??
-        session['shib'] = shib_meta
+
 
         if error:
             raise ShibbolethValidationError("All required Shibboleth elements"

--- a/shibboleth/backends.py
+++ b/shibboleth/backends.py
@@ -1,24 +1,18 @@
 from django.db import connection
 from django.contrib.auth.models import User, Permission
+from django.contrib.auth import get_user_model
 from django.contrib.auth.backends import RemoteUserBackend
 from shibboleth.app_settings import SHIB_ATTRIBUTE_MAP
 import re
 
 
+
+
 class ShibbolethRemoteUserBackend(RemoteUserBackend):
     """
-    This backend is to be used in conjunction with the ``RemoteUserMiddleware``
-    found in the middleware module of this package, and is used when the server
-    is handling authentication outside of Django.
-
-    By default, the ``authenticate`` method creates ``User`` objects for
-    usernames that don't already exist in the database.  Subclasses can disable
-    this behavior by setting the ``create_unknown_user`` attribute to
-    ``False``.
+    Inherits from and slightly modifies copies https://docs.djangoproject.com/en/1.6/_modules/django/contrib/auth/backends/#RemoteUserBackend
     """
 
-    # Create a User object if not already in the database?
-    create_unknown_user = True
 
     def authenticate(self, remote_user, meta):
         """
@@ -32,32 +26,30 @@ class ShibbolethRemoteUserBackend(RemoteUserBackend):
         if not remote_user:
             return
         user = None
-        username = remote_user
+        username = self.clean_username(remote_user)
 
+        UserModel = get_user_model()
 
-        # Make sure we have all required Shiboleth elements before proceeding.
-        shib_meta, error = self.parse_attributes(meta)
-
-
-        if error:
-            raise ShibbolethValidationError("All required Shibboleth elements"
-                                            " not found.  %s" % shib_meta)
-
-        shib_user_params = dict([(k, shib_meta[k]) for k in User._meta.get_all_field_names() if k in shib_meta])
         # Note that this could be accomplished in one try-except clause, but
         # instead we use get_or_create when creating unknown users since it has
         # built-in safeguards for multiple threads.
         if self.create_unknown_user:
-            user, created = User.objects.get_or_create(**shib_user_params)
+            user, created = UserModel._default_manager.get_or_create(**{
+                UserModel.USERNAME_FIELD: username
+            })
             if created:
-                user = self.configure_user(user)
-                user.set_unusable_password()
-                user.save()
+                user = self.configure_user(user,meta)
         else:
             try:
-                user = User.objects.get(**shib_user_params)
-            except User.DoesNotExist:
+                user = UserModel._default_manager.get_by_natural_key(username)
+            except UserModel.DoesNotExist:
                 pass
+        return user
+
+    def configure_user(user,meta):
+        # TODO: parase the entries defined from SHIBBOLETH_ATTRIBUTE_MAP and put them from meta into user 
+        user.set_unusable_password()
+        user.save() # necessary?
         return user
 
     def clean_username(self,value):
@@ -67,25 +59,6 @@ class ShibbolethRemoteUserBackend(RemoteUserBackend):
         # remove special characters
         value = ''.join(e for e in value if e.isalnum())
         return value
-
-    def parse_attributes(self, meta):
-        """
-        Parse the incoming Shibboleth attributes.
-        From: https://github.com/russell/django-shibboleth/blob/master/django_shibboleth/utils.py
-        Pull the mapped attributes from the apache headers.
-        """
-        shib_attrs = {}
-        error = False
-        for header, attr in SHIB_ATTRIBUTE_MAP.items():
-            required, name = attr
-            value = meta.get(header, None)
-            if name == "username":
-                value = self.clean_username(value)
-            shib_attrs[name] = value
-            if not value or value == '':
-                if required:
-                    error = True
-        return shib_attrs, error
 
 class ShibbolethValidationError(Exception):
     pass

--- a/shibboleth/backends.py
+++ b/shibboleth/backends.py
@@ -33,7 +33,6 @@ class ShibbolethRemoteUserBackend(RemoteUserBackend):
             return
         user = None
         username = remote_user
-        # the fact that username is not checked against the shibboleth-ID is a security hole here.
 
 
         # Make sure we have all required Shiboleth elements before proceeding.

--- a/shibboleth/backends.py
+++ b/shibboleth/backends.py
@@ -20,7 +20,7 @@ class ShibbolethRemoteUserBackend(RemoteUserBackend):
     # Create a User object if not already in the database?
     create_unknown_user = True
 
-    def authenticate(self, remote_user, META_HEADERS):
+    def authenticate(self, remote_user, meta):
         """
         The username passed as ``remote_user`` is considered trusted.  This
         method simply returns the ``User`` object with the given username,
@@ -36,7 +36,7 @@ class ShibbolethRemoteUserBackend(RemoteUserBackend):
 
 
         # Make sure we have all required Shiboleth elements before proceeding.
-        shib_meta, error = self.parse_attributes(META_HEADERS)
+        shib_meta, error = self.parse_attributes(meta)
 
 
         if error:
@@ -51,6 +51,8 @@ class ShibbolethRemoteUserBackend(RemoteUserBackend):
             user, created = User.objects.get_or_create(**shib_user_params)
             if created:
                 user = self.configure_user(user)
+                user.set_unusable_password()
+                user.save()
         else:
             try:
                 user = User.objects.get(**shib_user_params)

--- a/shibboleth/context_processors.py
+++ b/shibboleth/context_processors.py
@@ -8,7 +8,7 @@ def login_link(request):
     """
     full_path = quote(request.get_full_path())
     login = reverse('shibboleth:login')
-    ll = "%s?target=%s" % (login, full_path)
+    ll = "%s?next=%s" % (login, full_path)
     return { 'login_link': ll }
 
 def logout_link(request, *args):
@@ -17,10 +17,10 @@ def logout_link(request, *args):
     and uses the 'target' url parameter.
     e.g: https://school.edu/Shibboleth.sso/Login
     """
-    from app_settings import LOGOUT_URL, LOGOUT_REDIRECT_URL
+    from app_settings import LOGOUT_REDIRECT_URL
     #LOGOUT_REDIRECT_URL specifies a default logout page that will always be used when
     #users logout from Shibboleth.
     target = LOGOUT_REDIRECT_URL or quote(request.build_absolute_uri())
     logout = reverse('shibboleth:logout')
-    ll = "%s?target=%s" % (logout, target)
+    ll = "%s?next=%s" % (logout, target)
     return { 'logout_link': ll }

--- a/shibboleth/middleware.py
+++ b/shibboleth/middleware.py
@@ -19,14 +19,6 @@ class ShibbolethRemoteUserMiddleware(RemoteUserMiddleware):
                 " 'django.contrib.auth.middleware.AuthenticationMiddleware'"
                 " before the RemoteUserMiddleware class.")
 
-        #To support logout.  If this variable is True, do not
-        #authenticate user and return now.
-        if request.session.get(LOGOUT_SESSION_KEY) == True:
-            return
-        else:
-            #Delete the shib reauth session key if present.
-            request.session.pop(LOGOUT_SESSION_KEY, None)
-
         #Locate the remote user header.
         try:
             # self.header is set to REMOTE_USER. This variable is populated by shibboleth and it is by design what the user CLAIMS to be.
@@ -47,11 +39,9 @@ class ShibbolethRemoteUserMiddleware(RemoteUserMiddleware):
         # We are seeing this user for the first time in this session, attempt
         # to authenticate the user.
         # The last two arguments look strang and in fact I want to remove them as I think they reflect a security problem.
-        user = auth.authenticate(remote_user=username, META_HEADERS=request.META)
+        user = auth.authenticate(remote_user=username, meta=request.META)
         if user:
             # User is valid.  Set request.user and persist user in the session
             # by logging the user in.
             request.user = user
             auth.login(request, user)
-            user.set_unusable_password()
-            user.save()

--- a/shibboleth/middleware.py
+++ b/shibboleth/middleware.py
@@ -1,8 +1,8 @@
 from django.contrib.auth.middleware import RemoteUserMiddleware
 from django.contrib import auth
 from django.core.exceptions import ImproperlyConfigured
-
 from shibboleth.app_settings import LOGOUT_SESSION_KEY
+
 
 class ShibbolethRemoteUserMiddleware(RemoteUserMiddleware):
     """
@@ -25,11 +25,11 @@ class ShibbolethRemoteUserMiddleware(RemoteUserMiddleware):
             return
         else:
             #Delete the shib reauth session key if present.
-	        request.session.pop(LOGOUT_SESSION_KEY, None)
+            request.session.pop(LOGOUT_SESSION_KEY, None)
 
         #Locate the remote user header.
         try:
-            # self.header is set to REMOTE_USER. This is what the user CLAIMS to be.
+            # self.header is set to REMOTE_USER. This variable is populated by shibboleth and it is by design what the user CLAIMS to be.
             username = request.META[self.header]
         except KeyError:
             # If specified header doesn't exist then return (leaving
@@ -55,23 +55,3 @@ class ShibbolethRemoteUserMiddleware(RemoteUserMiddleware):
             auth.login(request, user)
             user.set_unusable_password()
             user.save()
-            # call make profile.
-            #self.make_profile(user, shib_meta)
-            #setup session.
-            #self.setup_session(request)
-
-    # def make_profile(self, user, shib_meta):
-    #     """
-    #     This is here as a stub to allow subclassing of ShibbolethRemoteUserMiddleware
-    #     to include a make_profile method that will create a Django user profile
-    #     from the Shib provided attributes.  By default it does nothing.
-    #     """
-    #     return
-
-    # def setup_session(self, request):
-    #     """
-    #     If you want to add custom code to setup user sessions, you
-    #     can extend this.
-    #     """
-    #     return
-

--- a/shibboleth/middleware.py
+++ b/shibboleth/middleware.py
@@ -47,7 +47,7 @@ class ShibbolethRemoteUserMiddleware(RemoteUserMiddleware):
         # We are seeing this user for the first time in this session, attempt
         # to authenticate the user.
         # The last two arguments look strang and in fact I want to remove them as I think they reflect a security problem.
-        user = auth.authenticate(remote_user=username, META_HEADERS=request.META, session=request.session)
+        user = auth.authenticate(remote_user=username, META_HEADERS=request.META)
         if user:
             # User is valid.  Set request.user and persist user in the session
             # by logging the user in.

--- a/shibboleth/middleware.py
+++ b/shibboleth/middleware.py
@@ -1,14 +1,18 @@
 from django.contrib.auth.middleware import RemoteUserMiddleware
+from django.contrib.auth import load_backend
+from django.contrib.auth.backends import RemoteUserBackend
 from django.contrib import auth
 from django.core.exceptions import ImproperlyConfigured
-from shibboleth.app_settings import LOGOUT_SESSION_KEY
+from shibboleth.app_settings import SHIBBOLETH_USER_KEY
 
 
 class ShibbolethRemoteUserMiddleware(RemoteUserMiddleware):
     """
-    Authentication Middleware for use with Shibboleth.  Uses the recommended pattern
-    for remote authentication from: http://code.djangoproject.com/svn/django/tags/releases/1.3/django/contrib/auth/middleware.py
+    Inherits from https://docs.djangoproject.com/en/1.6/_modules/django/contrib/auth/middleware/#RemoteUserMiddleware
+    with minimal modifications
     """
+    header=SHIBBOLETH_USER_KEY
+
     def process_request(self, request):
         # AuthenticationMiddleware is required so that request.user exists.
         if not hasattr(request, 'user'):
@@ -18,30 +22,46 @@ class ShibbolethRemoteUserMiddleware(RemoteUserMiddleware):
                 " MIDDLEWARE_CLASSES setting to insert"
                 " 'django.contrib.auth.middleware.AuthenticationMiddleware'"
                 " before the RemoteUserMiddleware class.")
-
-        #Locate the remote user header.
         try:
-            # self.header is set to REMOTE_USER. This variable is populated by shibboleth and it is by design what the user CLAIMS to be.
             username = request.META[self.header]
         except KeyError:
-            # If specified header doesn't exist then return (leaving
-            # request.user set to AnonymousUser by the
-            # AuthenticationMiddleware).
+            # If specified header doesn't exist then remove any existing
+            # authenticated remote-user, or return (leaving request.user set to
+            # AnonymousUser by the AuthenticationMiddleware).
+            if request.user.is_authenticated():
+                self._remove_invalid_user(request)
             return
         # If the user is already authenticated and that user is the user we are
         # getting passed in the headers, then the correct user is already
         # persisted in the session and we don't need to continue.
         if request.user.is_authenticated():
-            if request.user.username == self.clean_username(username, request):
+            if request.user.get_username() == self.clean_username(username, request):
                 return
-
+            else:
+                # An authenticated user is associated with the request, but
+                # it does not match the authorized user in the header.
+                self._remove_invalid_user(request)
 
         # We are seeing this user for the first time in this session, attempt
         # to authenticate the user.
-        # The last two arguments look strang and in fact I want to remove them as I think they reflect a security problem.
-        user = auth.authenticate(remote_user=username, meta=request.META)
+        user = auth.authenticate(remote_user=username,meta=request.META)
         if user:
             # User is valid.  Set request.user and persist user in the session
             # by logging the user in.
             request.user = user
             auth.login(request, user)
+
+
+    def _remove_invalid_user(self, request):
+        """
+        Removes the current authenticated user in the request which is invalid
+        but only if the user is authenticated via the RemoteUserBackend.
+        """
+        try:
+            stored_backend = load_backend(request.session.get(auth.BACKEND_SESSION_KEY, ''))
+        except ImproperlyConfigured:
+            # backend failed to load
+            auth.logout(request)
+        else:
+            if isinstance(stored_backend, RemoteUserBackend):
+                auth.logout(request)

--- a/shibboleth/views.py
+++ b/shibboleth/views.py
@@ -12,7 +12,7 @@ from django.views.generic import TemplateView
 from urllib import quote
 
 #Logout settings.
-from shibboleth.app_settings import SHIBBOLETH_LOGIN_URL, SHIBBOLETH_LOGOUT_URL, LOGOUT_REDIRECT_URL, LOGOUT_SESSION_KEY
+from shibboleth.app_settings import SHIBBOLETH_LOGIN_URL, SHIBBOLETH_LOGOUT_URL, LOGOUT_REDIRECT_URL
 
 class ShibbolethView(TemplateView):
     """

--- a/shibboleth/views.py
+++ b/shibboleth/views.py
@@ -12,7 +12,7 @@ from django.views.generic import TemplateView
 from urllib import quote
 
 #Logout settings.
-from shibboleth.app_settings import LOGOUT_URL, LOGOUT_REDIRECT_URL, LOGOUT_SESSION_KEY
+from shibboleth.app_settings import SHIBBOLETH_LOGIN_URL, SHIBBOLETH_LOGOUT_URL, LOGOUT_REDIRECT_URL, LOGOUT_SESSION_KEY
 
 class ShibbolethView(TemplateView):
     """
@@ -44,16 +44,16 @@ class ShibbolethView(TemplateView):
 
 class ShibbolethLoginView(TemplateView):
     """
-    Pass the user to the Shibboleth login page.
+    Pass the user to the Shibboleth logout page.
     Some code borrowed from:
     https://github.com/stefanfoulis/django-class-based-auth-views.
     """
-    redirect_field_name = "target"
+    redirect_field_name = "next"
 
     def get(self, *args, **kwargs):
         #Remove session value that is forcing Shibboleth reauthentication.
         self.request.session.pop(LOGOUT_SESSION_KEY, None)
-        login = settings.LOGIN_URL + '?target=%s' % quote(self.request.GET.get(self.redirect_field_name))
+        login = SHIBBOLETH_LOGIN_URL + '?target=%s' % quote(self.request.GET.get(self.redirect_field_name))
         return redirect(login)
     
 class ShibbolethLogoutView(TemplateView):
@@ -62,7 +62,7 @@ class ShibbolethLogoutView(TemplateView):
     Some code borrowed from:
     https://github.com/stefanfoulis/django-class-based-auth-views.
     """
-    redirect_field_name = "target"
+    redirect_field_name = "next"
 
     def get(self, *args, **kwargs):
         #Log the user out.
@@ -74,7 +74,7 @@ class ShibbolethLogoutView(TemplateView):
         target = LOGOUT_REDIRECT_URL or\
                  quote(self.request.GET.get(self.redirect_field_name)) or\
                  quote(request.build_absolute_uri())
-        logout = LOGOUT_URL % target
+        logout = SHIBBOLETH_LOGOUT_URL + '?target=%s' % target
         return redirect(logout)
 
 

--- a/shibboleth/views.py
+++ b/shibboleth/views.py
@@ -65,16 +65,13 @@ class ShibbolethLogoutView(TemplateView):
     redirect_field_name = "next"
 
     def get(self, *args, **kwargs):
-        #Log the user out.
+        #Log the user out. This means a full logout from shibboleth. There is no such thing as logging out from the service, but staying logged into shibboleth. It is single-sign on. Either you're signed in to all, or not.
         auth.logout(self.request)
-        #Set session key that middleware will use to force 
-        #Shibboleth reauthentication.
-        self.request.session[LOGOUT_SESSION_KEY] = True
-        #Get target url in order of preference.
         target = LOGOUT_REDIRECT_URL or\
                  quote(self.request.GET.get(self.redirect_field_name)) or\
                  quote(request.build_absolute_uri())
         logout = SHIBBOLETH_LOGOUT_URL + '?target=%s' % target
+
         return redirect(logout)
 
 

--- a/shibboleth/views.py
+++ b/shibboleth/views.py
@@ -1,5 +1,3 @@
-
-
 from django.conf import settings
 from django.contrib import auth
 from django.contrib.auth.decorators import login_required
@@ -51,8 +49,6 @@ class ShibbolethLoginView(TemplateView):
     redirect_field_name = "next"
 
     def get(self, *args, **kwargs):
-        #Remove session value that is forcing Shibboleth reauthentication.
-        self.request.session.pop(LOGOUT_SESSION_KEY, None)
         login = SHIBBOLETH_LOGIN_URL + '?target=%s' % quote(self.request.GET.get(self.redirect_field_name))
         return redirect(login)
     


### PR DESCRIPTION
Code improvements and improvements on the logout process.

Even before this commit, the logout process was not functional without using
the view - based login. Also there was a conflict between the redirect directive
used in this package (target) and the default django redirect directive (next).
This was the core of issue number #8.

As its main change, this commit abstracts the LOGIN_URL, which is a native
django setting, from the SHIBBOLETH_LOGIN_URL. If you are using the view-based login,

LOGIN_URL should now point to /shib/login , where the login-view is based, and
SHIBBOLETH_LOGIN_URL shoudl be set to the shibboleth login handler.
https:// example.com/Shibboleth.sso/Login.

You can still avoid the usage of views by pointing LOGIN_URL directly to the
shibboleth login handler. However, this is not recommended.

I have not edited the readme yet. If the 
