### PR TITLE
syntax fix in example SHIBBOLETH_ATTRIBUTE_MAP

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Installation and configuration
 
     ```python
     SHIBBOLETH_ATTRIBUTE_MAP = {
-       "HTTP_SHIB_USER": (True, "username"),,
+       "HTTP_SHIB_USER": (True, "username"),
        "HTTP_SHIB_GIVEN_NAME": (True, "first_name"),
        "HTTP_SHIP_SN": (True, "last_name"),
        "HTTP_SHIB_MAIL": (False, "email"),


### PR DESCRIPTION
There is a trivial typo in the README file. The second comma causes a syntax error. 

It should not prevent anybody from using this module but I myself did not notice it when I was editing the example `SHIBBOLETH_ATTRIBUTE_MAP`, and it would be nicer if it's fixed.

cheers,
Ties
