### PR TITLE
to create a new user only the username must match

### DIFF
--- a/shibboleth/backends.py
+++ b/shibboleth/backends.py
@@ -35,7 +35,7 @@ class ShibbolethRemoteUserBackend(RemoteUserBackend):
         # instead we use get_or_create when creating unknown users since it has
         # built-in safeguards for multiple threads.
         if self.create_unknown_user:
-            user, created = User.objects.get_or_create(**shib_user_params)
+            user, created = User.objects.get_or_create(username=shib_user_params.get('username'), defaults=shib_user_params)
             if created:
                 user = self.configure_user(user)
         else:


### PR DESCRIPTION
If a shibboleth param of a user changed an error "Duplicate entry 'XY' for key 'username'" was thrown.
Therefore only create a new user if the username doesn't exist yet.
