### PR TITLE
Remove django 1.6 and 1.7 from testing, since they're EOL, and remove…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@
 language: python
 # List the versions of Python you'd like to test against
 python:
-  - "2.6"
   - "2.7"
   - "3.2"
   - "3.3"
@@ -11,33 +10,15 @@ python:
 
 # List the versions of Django you'd like to test against
 env:
-  - DJANGO_VERSION=1.6
-  - DJANGO_VERSION=1.7
   - DJANGO_VERSION=1.8
   - DJANGO_VERSION=1.9
 
 matrix:
   exclude:
-    - python: "2.6"
-      env: DJANGO_VERSION=1.7
-    - python: "2.6"
-      env: DJANGO_VERSION=1.8
-    - python: "2.6"
-      env: DJANGO_VERSION=1.9
-    - python: "3.2"
-      env: DJANGO_VERSION=1.6
     - python: "3.2"
       env: DJANGO_VERSION=1.9
     - python: "3.3"
-      env: DJANGO_VERSION=1.6
-    - python: "3.3"
       env: DJANGO_VERSION=1.9
-    - python: "3.4"
-      env: DJANGO_VERSION=1.6
-    - python: "3.5"
-      env: DJANGO_VERSION=1.6
-    - python: "3.5"
-      env: DJANGO_VERSION=1.7
     
 install: 
    # Travis is currently working on


### PR DESCRIPTION
… python 2.6 since django 1.8 requires python 2.7