### PR TITLE
Replace url pattern in urls.py for Django 1.10 compatibility

### DIFF
--- a/shibboleth/urls.py
+++ b/shibboleth/urls.py
@@ -1,10 +1,10 @@
 import django
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from .views import ShibbolethView, ShibbolethLogoutView, ShibbolethLoginView
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^login/$', ShibbolethLoginView.as_view(), name='login'),
     url(r'^logout/$', ShibbolethLogoutView.as_view(), name='logout'),
     url(r'^$', ShibbolethView.as_view(), name='info'),
-)
+]


### PR DESCRIPTION
Hi,
In my current Django 1.9.5 installation the module throws some deprecated warings about for Django 1.10:

    /usr/local/share/myproject/shibboleth/urls.py:9: RemovedInDjango110Warning: django.conf.urls.patterns() is deprecated and will be removed in Django 1.10. Update your urlpatterns to be a list of django.conf.urls.url() instances instead.
    url(r'^$', ShibbolethView.as_view(), name='info'),

This patch makes django-shibboleth-remoteuser compatible with the upcomming Django version 1.10.


Best Regards,
Sören