### PR TITLE
Always set user attributes from shibboleth parameters

### DIFF
--- a/shibboleth/backends.py
+++ b/shibboleth/backends.py
@@ -48,7 +48,8 @@ class ShibbolethRemoteUserBackend(RemoteUserBackend):
                 return
         # After receiving a valid user, we update the the user attributes according to the shibboleth
         # parameters. Otherwise the parameters (like mail address, sure_name or last_name) will always
-        # be the initial values from the first login
-        user.__dict__.update(**shib_user_params)
-        user.save()
+        # be the initial values from the first login. Only save user object if there are any changes.
+        if not min([getattr(user, k) == v for k, v in shib_user_params.items()]):
+            user.__dict__.update(**shib_user_params)
+            user.save()
         return user

--- a/shibboleth/middleware.py
+++ b/shibboleth/middleware.py
@@ -4,6 +4,7 @@ from django.core.exceptions import ImproperlyConfigured
 
 from shibboleth.app_settings import SHIB_ATTRIBUTE_MAP, LOGOUT_SESSION_KEY
 
+
 class ShibbolethRemoteUserMiddleware(RemoteUserMiddleware):
     """
     Authentication Middleware for use with Shibboleth.  Uses the recommended pattern
@@ -19,15 +20,15 @@ class ShibbolethRemoteUserMiddleware(RemoteUserMiddleware):
                 " 'django.contrib.auth.middleware.AuthenticationMiddleware'"
                 " before the RemoteUserMiddleware class.")
 
-        #To support logout.  If this variable is True, do not
-        #authenticate user and return now.
-        if request.session.get(LOGOUT_SESSION_KEY) == True:
+        # To support logout.  If this variable is True, do not
+        # authenticate user and return now.
+        if request.session.get(LOGOUT_SESSION_KEY):
             return
         else:
-            #Delete the shib reauth session key if present.
-	        request.session.pop(LOGOUT_SESSION_KEY, None)
+            # Delete the shib reauth session key if present.
+            request.session.pop(LOGOUT_SESSION_KEY, None)
 
-        #Locate the remote user header.
+        # Locate the remote user header.
         try:
             username = request.META[self.header]
         except KeyError:
@@ -62,7 +63,7 @@ class ShibbolethRemoteUserMiddleware(RemoteUserMiddleware):
             user.save()
             # call make profile.
             self.make_profile(user, shib_meta)
-            #setup session.
+            # setup session.
             self.setup_session(request)
 
     def make_profile(self, user, shib_meta):
@@ -80,9 +81,10 @@ class ShibbolethRemoteUserMiddleware(RemoteUserMiddleware):
         """
         return
 
-    def parse_attributes(self, request):
+    @staticmethod
+    def parse_attributes(request):
         """
-        Parse the incoming Shibboleth attributes.
+        Parse the incoming Shibboleth attributes and convert them to the internal data structure.
         From: https://github.com/russell/django-shibboleth/blob/master/django_shibboleth/utils.py
         Pull the mapped attributes from the apache headers.
         """
@@ -97,6 +99,7 @@ class ShibbolethRemoteUserMiddleware(RemoteUserMiddleware):
                 if required:
                     error = True
         return shib_attrs, error
+
 
 class ShibbolethValidationError(Exception):
     pass


### PR DESCRIPTION
Hello again,
here is a patch for a bug I found during my development.
When the attributes of a shibboleth user changes they will never be reflected in the Django database. This is especially important when the mail address changes. If you want I can make this optional by a special settings parameter like SHIBBOLETH_ALWAYS_UPDATE_USER. But I think there is no requirement for this, because you always want the correct user details in the Django database.


In addition there was also a Django 1.10 deprecated warning:

    /usr/local/share/myproject/shibboleth/backends.py:36: RemovedInDjango110Warning: 'get_all_field_names is an unofficial API that has been deprecated. You may be able to replace it with 'get_fields()'
    shib_user_params = dict([(k, shib_meta[k]) for k in User._meta.get_all_field_names() if k in shib_meta])

I fixed this according to https://docs.djangoproject.com/es/1.9/ref/models/meta/

I also removed some unused libraries at the top.

Best Regards
Sören
