### PR TITLE
Prevent inactive users from logging in.

### DIFF
--- a/shibboleth/backends.py
+++ b/shibboleth/backends.py
@@ -62,4 +62,15 @@ class ShibbolethRemoteUserBackend(RemoteUserBackend):
         if not min([getattr(user, k) == v for k, v in shib_user_params.items()]):
             user.__dict__.update(**shib_user_params)
             user.save()
-        return user
+        return user if self.user_can_authenticate(user) else None
+
+    def user_can_authenticate(self, user):
+        """
+        Reject users with is_active=False. Custom user models that don't have
+        that attribute are allowed.
+
+        This is already provided in Django 1.10+ - included here to support
+        lower versions
+        """
+        is_active = getattr(user, 'is_active', None)
+        return is_active or is_active is None

--- a/shibboleth/tests/test_shib.py
+++ b/shibboleth/tests/test_shib.py
@@ -153,6 +153,13 @@ class TestShibbolethRemoteUserBackend(TestCase):
         # now reload again, so it reverts to original settings
         reload(backends)
 
+    def test_auth_inactive_user_false(self):
+        shib_meta = self._get_valid_shib_meta()
+        # Pre-create an inactive user
+        User.objects.create(username='sampledeveloper@school.edu', is_active=False)
+        user = auth.authenticate(remote_user='sampledeveloper@school.edu', shib_meta=shib_meta)
+        self.assertTrue(user is None)
+
     def test_ensure_user_attributes(self):
         shib_meta = self._get_valid_shib_meta()
         # Create / authenticate the test user and store another mail address


### PR DESCRIPTION
Django does this in more recent versions of its remote user middleware and it makes sense to do the same here. Ref. #50 