### PR TITLE
Remove LOGOUT_SESSION_KEY code

### DIFF
--- a/shibboleth/app_settings.py
+++ b/shibboleth/app_settings.py
@@ -26,7 +26,3 @@ LOGOUT_URL = getattr(settings, 'SHIBBOLETH_LOGOUT_URL', None)
 #LOGOUT_REDIRECT_URL specifies a default logout page that will always be used when
 #users logout from Shibboleth.
 LOGOUT_REDIRECT_URL = getattr(settings, 'SHIBBOLETH_LOGOUT_REDIRECT_URL', None)
-#Name of key.  Probably no need to change this.  
-LOGOUT_SESSION_KEY = getattr(settings, 'SHIBBOLETH_FORCE_REAUTH_SESSION_KEY', 'shib_force_reauth')
-
-

--- a/shibboleth/middleware.py
+++ b/shibboleth/middleware.py
@@ -3,7 +3,7 @@ from django.contrib.auth.models import Group
 from django.contrib import auth
 from django.core.exceptions import ImproperlyConfigured
 
-from shibboleth.app_settings import SHIB_ATTRIBUTE_MAP, GROUP_ATTRIBUTES, LOGOUT_SESSION_KEY
+from shibboleth.app_settings import SHIB_ATTRIBUTE_MAP, GROUP_ATTRIBUTES
 
 
 class ShibbolethRemoteUserMiddleware(RemoteUserMiddleware):
@@ -20,14 +20,6 @@ class ShibbolethRemoteUserMiddleware(RemoteUserMiddleware):
                 " MIDDLEWARE_CLASSES setting to insert"
                 " 'django.contrib.auth.middleware.AuthenticationMiddleware'"
                 " before the RemoteUserMiddleware class.")
-
-        # To support logout.  If this variable is True, do not
-        # authenticate user and return now.
-        if request.session.get(LOGOUT_SESSION_KEY):
-            return
-        else:
-            # Delete the shib reauth session key if present.
-            request.session.pop(LOGOUT_SESSION_KEY, None)
 
         # Locate the remote user header.
         try:

--- a/shibboleth/tests/test_shib.py
+++ b/shibboleth/tests/test_shib.py
@@ -238,6 +238,9 @@ class LogoutTest(TestCase):
         # Login
         login = self.client.get('/', **SAMPLE_HEADERS)
         self.assertEqual(login.status_code, 200)
+        # Check login
+        login = self.client.get('/')
+        self.assertEqual(login.status_code, 200)
         # Logout
         logout = self.client.get('/logout/', **SAMPLE_HEADERS)
         self.assertEqual(logout.status_code, 302)
@@ -246,10 +249,8 @@ class LogoutTest(TestCase):
             logout['Location'],
             'https://sso.school.edu/logout?next=http://school.edu/'
         )
-        # Check to see if the session has the force logout key.
-        self.assertTrue(self.client.session.get(app_settings.LOGOUT_SESSION_KEY))
         # Load root url to see if user is in fact logged out.
-        resp = self.client.get('/', **SAMPLE_HEADERS)
+        resp = self.client.get('/')
         self.assertEqual(resp.status_code, 302)
         # Make sure the context is empty.
         self.assertEqual(resp.context, None)

--- a/shibboleth/views.py
+++ b/shibboleth/views.py
@@ -13,7 +13,7 @@ except ImportError:
     from urllib import quote
 
 #Logout settings.
-from shibboleth.app_settings import LOGOUT_URL, LOGOUT_REDIRECT_URL, LOGOUT_SESSION_KEY
+from shibboleth.app_settings import LOGOUT_URL, LOGOUT_REDIRECT_URL
 
 
 class ShibbolethView(TemplateView):
@@ -55,7 +55,6 @@ class ShibbolethLoginView(TemplateView):
 
     def get(self, *args, **kwargs):
         #Remove session value that is forcing Shibboleth reauthentication.
-        self.request.session.pop(LOGOUT_SESSION_KEY, None)
         login = settings.LOGIN_URL + '?target=%s' % quote(self.request.GET.get(self.redirect_field_name, ''))
         return redirect(login)
 
@@ -71,9 +70,6 @@ class ShibbolethLogoutView(TemplateView):
     def get(self, request, *args, **kwargs):
         #Log the user out.
         auth.logout(self.request)
-        #Set session key that middleware will use to force 
-        #Shibboleth reauthentication.
-        self.request.session[LOGOUT_SESSION_KEY] = True
         #Get target url in order of preference.
         target = LOGOUT_REDIRECT_URL or\
                  quote(self.request.GET.get(self.redirect_field_name, '')) or\


### PR DESCRIPTION
If the local shibboleth sp session gets properly destroyed by
redirecting to the logout endpoint (usually /Shibboleth.sso/Logout),
this workaround shouldn't be necessary (anymore).

Closes #59