### PR TITLE
Configurable group delimiters

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -165,6 +165,23 @@ You may check your group attributes at
 before activating this feature.
 
 
+Fields identified in ``SHIBBOLETH_GROUP_ATTRIBUTES`` can be a string of group
+names with a delimiter. By default the delimiter is `;`, but this can be
+overridden to be one or many delimiters using the ``SHIBBOLETH_GROUP_DELIMITERS``
+setting.
+
+For example, given:
+  - ``SHIBBOLETH_GROUP_ATTRIBUTES = ['Shibboleth-isMemberOf']``
+  - request headers includes: ``Shibboleth-isMemberOf: 'users;admins,managers'``
+
+=========================== =======================================
+SHIBBOLETH_GROUP_DELIMITERS Parsed Groups
+=========================== =======================================
+default                     ``users`` and ``admins,managers``
+``[',']``                   ``users;admins`` and ``managers``
+``[',', ';']``              ``users``, ``admins``, and ``managers``
+=========================== =======================================
+
 .. |build-status| image:: https://travis-ci.org/Brown-University-Library/django-shibboleth-remoteuser.svg?branch=master&style=flat
    :target: https://travis-ci.org/Brown-University-Library/django-shibboleth-remoteuser
    :alt: Build status

--- a/shibboleth/app_settings.py
+++ b/shibboleth/app_settings.py
@@ -19,6 +19,10 @@ if not LOGIN_URL:
 # This list of attributes will map to Django permission groups
 GROUP_ATTRIBUTES = getattr(settings, 'SHIBBOLETH_GROUP_ATTRIBUTES', [])
 
+# If a group attribute is actually a list of groups, define the
+# delimiters used to split the list
+GROUP_DELIMITERS = getattr(settings, 'SHIBBOLETH_GROUP_DELIMITERS', [';', ','])
+
 #Optional logout parameters
 #This should look like: https://sso.school.edu/idp/logout.jsp?return=%s
 #The return url variable will be replaced in the LogoutView.

--- a/shibboleth/app_settings.py
+++ b/shibboleth/app_settings.py
@@ -21,7 +21,7 @@ GROUP_ATTRIBUTES = getattr(settings, 'SHIBBOLETH_GROUP_ATTRIBUTES', [])
 
 # If a group attribute is actually a list of groups, define the
 # delimiters used to split the list
-GROUP_DELIMITERS = getattr(settings, 'SHIBBOLETH_GROUP_DELIMITERS', [';', ','])
+GROUP_DELIMITERS = getattr(settings, 'SHIBBOLETH_GROUP_DELIMITERS', [';'])
 
 #Optional logout parameters
 #This should look like: https://sso.school.edu/idp/logout.jsp?return=%s

--- a/shibboleth/middleware.py
+++ b/shibboleth/middleware.py
@@ -2,8 +2,9 @@ from django.contrib.auth.middleware import RemoteUserMiddleware
 from django.contrib.auth.models import Group
 from django.contrib import auth
 from django.core.exceptions import ImproperlyConfigured
+import re
 
-from shibboleth.app_settings import SHIB_ATTRIBUTE_MAP, GROUP_ATTRIBUTES, LOGOUT_SESSION_KEY
+from shibboleth.app_settings import SHIB_ATTRIBUTE_MAP, GROUP_ATTRIBUTES, LOGOUT_SESSION_KEY, GROUP_DELIMITERS
 
 
 class ShibbolethRemoteUserMiddleware(RemoteUserMiddleware):
@@ -126,7 +127,9 @@ class ShibbolethRemoteUserMiddleware(RemoteUserMiddleware):
         """
         groups = []
         for attr in GROUP_ATTRIBUTES:
-            groups += filter(bool, request.META.get(attr, '').split(';'))
+            parsed_groups = re.split('|'.join(GROUP_DELIMITERS),
+                                     request.META.get(attr, ''))
+            groups += filter(bool, parsed_groups)
         return groups
 
 


### PR DESCRIPTION
In the existing code, the SHIBBOLETH_GROUP_ATTRIBUTES expects any list-based attributes to be semicolon delimited.

My project actually receives a list of comma separated groups, and a code change was required to support commas instead of semicolons.

I erred on the side of flexibility by allowing multiple delimiters to be specified (e.g. both comma and semicolon) in the off chance that more than one is needed.  Let me know if the README could be improved in any way.