### PR TITLE
Added option to add callables to attribute map

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 Setup script adapted from Datadesk's softhyphen project:
 https://github.com/datadesk/django-softhyphen/blob/master/setup.py
 
-Which says: 
+Which says:
 Tricks lifted from Django's own setup.py and django_debug_toolbar.
 
 Still not sure why the templates install with this particular config
@@ -25,7 +25,7 @@ class osx_install_data(install_data):
     # which is wrong. Python 2.5 supplied with MacOS 10.5 has an Apple-specific fix
     # for this in distutils.command.install_data#306. It fixes install_lib but not
     # install_data, which is why we roll our own install_data class.
-    
+
     def finalize_options(self):
         # By the time finalize_options is called, install.install_lib is set to the
         # fixed directory, so we set the installdir to install_lib. The
@@ -33,10 +33,10 @@ class osx_install_data(install_data):
         self.set_undefined_options('install', ('install_lib', 'install_dir'))
         install_data.finalize_options(self)
 
-if sys.platform == "darwin": 
-    cmdclasses = {'install_data': osx_install_data} 
-else: 
-    cmdclasses = {'install_data': install_data} 
+if sys.platform == "darwin":
+    cmdclasses = {'install_data': osx_install_data}
+else:
+    cmdclasses = {'install_data': install_data}
 
 def fullsplit(path, result=None):
     """
@@ -84,7 +84,7 @@ if len(sys.argv) > 1 and sys.argv[1] == 'bdist_wininst':
 
 setup(
       name = "django-shibboleth-remoteuser",
-      version='0.11a1',
+      version='0.11a2',
       long_description = read('README.rst'),
       author = 'Brown University Library',
       author_email = 'bdr@brown.edu',

--- a/shibboleth/middleware.py
+++ b/shibboleth/middleware.py
@@ -105,10 +105,14 @@ class ShibbolethRemoteUserMiddleware(RemoteUserMiddleware):
         error = False
         meta = request.META
         for header, attr in list(SHIB_ATTRIBUTE_MAP.items()):
-            required, name = attr
+            if len(attr) == 3:
+                required, name, attr_processor = attr
+            else:
+                required, name = attr
+                attr_processor = lambda x: x
             value = meta.get(header, None)
             if value:
-                shib_attrs[name] = value
+                shib_attrs[name] = attr_processor(value)
             elif required:
                 error = True
         return shib_attrs, error

--- a/shibboleth/tests/test_shib.py
+++ b/shibboleth/tests/test_shib.py
@@ -46,7 +46,8 @@ settings.SHIBBOLETH_ATTRIBUTE_MAP = {
    "Shib-Session-ID": (True, "session_id"),
    "Shibboleth-givenName": (True, "first_name"),
    "Shibboleth-sn": (True, "last_name"),
-   "Shibboleth-schoolBarCode": (False, "barcode")
+   "Shibboleth-schoolBarCode": (False, "barcode"),
+   "Shibboleth-displayName": (True, "shortened_name", lambda x: x[:5])
 }
 
 
@@ -222,6 +223,10 @@ class TestShibbolethParseAttributes(TestCase):
         self.assertFalse('barcode' in shib_meta.keys())
         self.assertFalse(error)
 
+    def test_mutated_attribute(self):
+        shib_meta, error = middleware.ShibbolethRemoteUserMiddleware.parse_attributes(self.test_request)
+        self.assertEqual(shib_meta["barcode"], SAMPLE_HEADERS["Shibboleth-schoolBarCode"])
+        self.assertEqual(shib_meta["shortened_name"], SAMPLE_HEADERS["Shibboleth-displayName"][:5])
 
 class TestShibbolethGroupAssignment(TestCase):
 


### PR DESCRIPTION
There are some cases where post-processing of the returned shibboleth values are necessary before saving them to the CAS application. This PR adds a way to pass a callable as the third element of the attribute map tuple to perform arbitrary mutations of the returned values.