### PR TITLE
Refactor backends.py for better extensibility

### DIFF
--- a/shibboleth/backends.py
+++ b/shibboleth/backends.py
@@ -3,6 +3,8 @@ from django.contrib.auth.backends import RemoteUserBackend
 from django.conf import settings
 import inspect
 
+User = get_user_model()
+
 
 class ShibbolethRemoteUserBackend(RemoteUserBackend):
     """
@@ -17,62 +19,75 @@ class ShibbolethRemoteUserBackend(RemoteUserBackend):
     """
 
     # Create a User object if not already in the database?
-    create_unknown_user = True
-    if hasattr(settings, 'CREATE_UNKNOWN_USER'):
-        create_unknown_user = settings.CREATE_UNKNOWN_USER
+    create_unknown_user = getattr(settings, 'CREATE_UNKNOWN_USER', True)
 
     def authenticate(self, request, remote_user, shib_meta):
         """
-        The username passed as ``remote_user`` is considered trusted.  This
-        method simply returns the ``User`` object with the given username,
+        The username passed as ``remote_user`` is considered trusted.  Use the
+        username to get or create the user.
+        """
+        if not remote_user:
+            return
+        username = self.clean_username(remote_user)
+        field_names = [x.name for x in User._meta.get_fields()]
+        shib_user_params = dict([(k, shib_meta[k]) for k in field_names if k in shib_meta])
+
+        user = self.setup_user(request=request, username=username, defaults=shib_user_params)
+        if user:
+            self.update_user_params(user=user, params=shib_user_params)
+            return user if self.user_can_authenticate(user) else None
+
+    def setup_user(self, request, username, defaults):
+        """
+        This method simply returns the ``User`` object with the given username,
         creating a new ``User`` object if ``create_unknown_user`` is ``True``.
 
         Returns None if ``create_unknown_user`` is ``False`` and a ``User``
         object with the given username is not found in the database.
         """
-        if not remote_user:
-            return
-        User = get_user_model()
-        username = self.clean_username(remote_user)
-        field_names = [x.name for x in User._meta.get_fields()]
-        shib_user_params = dict([(k, shib_meta[k]) for k in field_names if k in shib_meta])
+
         # Note that this could be accomplished in one try-except clause, but
         # instead we use get_or_create when creating unknown users since it has
         # built-in safeguards for multiple threads.
         if self.create_unknown_user:
-            user, created = User.objects.get_or_create(username=username, defaults=shib_user_params)
+            user, created = User.objects.get_or_create(username=username, defaults=defaults)
             if created:
-                """
-                @note: setting password for user needs on initial creation of user instead of after auth.login() of middleware.
-                because get_session_auth_hash() returns the salted_hmac value of salt and password.
-                If it remains after the auth.login() it will return a different auth_hash
-                than what's stored in session "request.session[HASH_SESSION_KEY]".
-                Also we don't need to update the user's password everytime he logs in.
-                """
-                user.set_unusable_password()
-                user.save()
-                args = (request, user)
-                try:
-                    inspect.signature(self.configure_user).bind(request, user)
-                except AttributeError:
-                    # getcallargs required for Python 2.7 support, deprecated after 3.5
-                    try:
-                        inspect.getcallargs(self.configure_user, request, user)
-                    except TypeError:
-                        args = (user,)
-                except TypeError:
-                    args = (user,)
-                user = self.configure_user(*args)
+                user = self.handle_created_user(request, user)
         else:
             try:
                 user = User.objects.get(username=username)
             except User.DoesNotExist:
                 return
-        # After receiving a valid user, we update the the user attributes according to the shibboleth
-        # parameters. Otherwise the parameters (like mail address, sure_name or last_name) will always
-        # be the initial values from the first login. Only save user object if there are any changes.
-        if not min([getattr(user, k) == v for k, v in shib_user_params.items()]):
-            user.__dict__.update(**shib_user_params)
-            user.save()
-        return user if self.user_can_authenticate(user) else None
+        return user
 
+    def handle_created_user(self, request, user):
+        """
+        @note: setting password for user needs on initial creation of user instead of after auth.login() of middleware.
+        because get_session_auth_hash() returns the salted_hmac value of salt and password.
+        If it remains after the auth.login() it will return a different auth_hash
+        than what's stored in session "request.session[HASH_SESSION_KEY]".
+        Also we don't need to update the user's password everytime he logs in.
+        """
+        user.set_unusable_password()
+        user.save()
+        args = (request, user)
+        try:
+            inspect.signature(self.configure_user).bind(request, user)
+        except AttributeError:
+            # getcallargs required for Python 2.7 support, deprecated after 3.5
+            try:
+                inspect.getcallargs(self.configure_user, request, user)
+            except TypeError:
+                args = (user,)
+        return self.configure_user(*args)
+
+    @staticmethod
+    def update_user_params(user, params):
+        """
+        After receiving a valid user, we update the the user attributes according to the shibboleth
+        parameters. Otherwise the parameters (like mail address, sure_name or last_name) will always
+        be the initial values from the first login. Only save user object if there are any changes.
+        """
+        if not min([getattr(user, k) == v for k, v in params.items()]):
+            user.__dict__.update(**params)
+            user.save()


### PR DESCRIPTION
I ran into a situation where I needed to tweak how we get users, and I couldn't really do much without replacing the entire authenticate method.

Rather than forking the functionality, I think it'd be logical to break up the authenticate method into smaller chunks for better extensibility.

NOTE: This PR doesn't add or remove any functionality, which is why I haven't adjusted any of the tests.

I refactored authenticate into 4 function:
- authenticate
  - setup_user
    - handle_created_user
  - update_user_params

This arrangement allows me to override setup_user, for example, without losing the update_user_params functionality.