### PR TITLE
Additional fix for quote importing

### DIFF
--- a/shibboleth/context_processors.py
+++ b/shibboleth/context_processors.py
@@ -2,7 +2,7 @@ try:
     from django.core.urlresolvers import reverse
 except ImportError:
     from django.urls import reverse
-from django.utils.six.moves.urllib_parse import quote
+from urllib.parse import quote
 
 def login_link(request):
     """


### PR DESCRIPTION
This fixes another occurrence of `from django.utils.six.moves.urllib_parse import quote` as mentioned for `views.py` in issue #85