### PR TITLE
django.conf.urls is deprecated in 3.x and was removed in 4.x

### DIFF
--- a/shibboleth/urls.py
+++ b/shibboleth/urls.py
@@ -1,12 +1,12 @@
 import django
-from django.conf.urls import url
+from django.urls import re_path
 
 from .views import ShibbolethView, ShibbolethLogoutView, ShibbolethLoginView
 
 app_name = 'shibboleth'
 
 urlpatterns = [
-    url(r'^login/$', ShibbolethLoginView.as_view(), name='login'),
-    url(r'^logout/$', ShibbolethLogoutView.as_view(), name='logout'),
-    url(r'^$', ShibbolethView.as_view(), name='info'),
+    re_path(r'^login/$', ShibbolethLoginView.as_view(), name='login'),
+    re_path(r'^logout/$', ShibbolethLogoutView.as_view(), name='logout'),
+    re_path(r'^$', ShibbolethView.as_view(), name='info'),
 ]


### PR DESCRIPTION
Please merge for Django 4.x compatibility.

Cheers