### PR TITLE
middleware: Allow to configure name of REMOTE_USER field.

### DIFF
--- a/shibboleth/app_settings.py
+++ b/shibboleth/app_settings.py
@@ -5,9 +5,11 @@ from django.core.exceptions import ImproperlyConfigured
 #At a minimum you will need username, 
 default_shib_attributes = {
   "REMOTE_USER": (True, "username"),
-} 
+}
+default_shib_username_attribute = 'REMOTE_USER'
 
 SHIB_ATTRIBUTE_MAP = getattr(settings, 'SHIBBOLETH_ATTRIBUTE_MAP', default_shib_attributes)
+SHIB_USERNAME_ATTRIBUTE = getattr(settings, 'SHIBBOLETH_USERNAME_ATTRIBUTE', default_shib_username_attribute)
 #Set to true if you are testing and want to insert sample headers.
 SHIB_MOCK_HEADERS = getattr(settings, 'SHIBBOLETH_MOCK_HEADERS', False)
 

--- a/shibboleth/middleware.py
+++ b/shibboleth/middleware.py
@@ -4,10 +4,11 @@ from django.contrib import auth
 from django.core.exceptions import ImproperlyConfigured
 import re
 
-from shibboleth.app_settings import SHIB_ATTRIBUTE_MAP, GROUP_ATTRIBUTES, GROUP_DELIMITERS
+from shibboleth.app_settings import SHIB_ATTRIBUTE_MAP, SHIB_USERNAME_ATTRIBUTE, GROUP_ATTRIBUTES, GROUP_DELIMITERS
 
 
 class ShibbolethRemoteUserMiddleware(RemoteUserMiddleware):
+    header = SHIB_USERNAME_ATTRIBUTE
     """
     Authentication Middleware for use with Shibboleth.  Uses the recommended pattern
     for remote authentication from: http://code.djangoproject.com/svn/django/tags/releases/1.3/django/contrib/auth/middleware.py


### PR DESCRIPTION
This adds a new configuration parameter `SHIBBOLETH_USERNAME_ATTRIBUTE`
which allows to configure the field used as username (e.g. one might want to use `persistent-id`).